### PR TITLE
remove unused and deprecated `react-addons` dependency

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -34,7 +34,6 @@ if(needs_write){
 
   browserify()
   .require('react')
-  .require('react-addons')
   .require('./js/App')
   .transform({global: true}, literalify.configure({react: 'window.React'}))
   .bundle(function (err, b) {

--- a/index.js
+++ b/index.js
@@ -176,7 +176,6 @@ global.TWITCH_OAUTH_URL = 'https://api.twitch.tv/kraken/oauth2/authorize?respons
 /////////////////
 // server side react js
 var React = require('react');
-var addons = require('react-addons');
 var App = React.createFactory(require('./js/App'))
 
 // cache the stream list from the API

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jsonfile": "^2.0.0",
     "literalify": "^0.4.0",
     "react": "^0.13.3",
-    "react-addons": "^0.9.1-deprecated",
     "react-tools": "^0.13.0",
     "redis": "^0.12.1",
     "request": "^2.53.0",


### PR DESCRIPTION
The `react-addons` module has been deprecated for over a year now in favor of simply doing `require('react/addons')`.